### PR TITLE
fix: cannot configure timeout for Guacamole API

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -10,24 +10,24 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout sources
+        uses: actions/checkout@v4
+
       - name: Set up JDK 11
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: 'corretto'
           java-version: 11
+          cache: 'maven'
           server-id: ossrh
           server-username: OSSRH_JIRA_USERNAME
           server-password: OSSRH_JIRA_PASSWORD
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           gpg-passphrase: OSSRH_GPG_SECRET_KEY_PASSWORD
-      - uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
+
       - name: Build with Maven
         run: mvn -B package
+
       - name: Deploy SNAPSHOT version
         run: mvn -B -DskipTests deploy
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,52 +11,37 @@ jobs:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK
-        uses: actions/setup-java@v1
+      - name: Checkout sources
+        uses: actions/checkout@v4
         with:
+          # Disabling shallow clone is needed for correctly determing next release with semantic release
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
           java-version: 11
+          cache: 'maven'
           server-id: ossrh
           server-username: OSSRH_JIRA_USERNAME
           server-password: OSSRH_JIRA_PASSWORD
           gpg-private-key: ${{ secrets.OSSRH_GPG_SECRET_KEY }}
           gpg-passphrase: OSSRH_GPG_SECRET_KEY_PASSWORD
-      - name: Cache for maven
-        uses: actions/cache@v2
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-          restore-keys: |
-            ${{ runner.os }}-maven-
-      - name: Setup node
-        uses: actions/setup-node@v1
-        with:
-          node-version: '10.x'
-      - name: Get yarn cache directory path
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-      - name: Cache for yarn
-        uses: actions/cache@v2
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-maven-semantic-release-v4.5.0
-          restore-keys: |
-            ${{ runner.os }}-yarn-
-      - name: Setup semantic-release
-        run: |
-          yarn global add @conveyal/maven-semantic-release@v4.5.0 semantic-release@15
-          echo "$(yarn global bin)" >> $GITHUB_PATH
+
       - name: Test
         run: mvn -B test
-      - name: Release
-        # maven-semantic-release requires "maven-settings.xml" in the workspace directory
-        run: |
-          mv ~/.m2/settings.xml maven-settings.xml
-          semantic-release --branch main --prepare @conveyal/maven-semantic-release \
-            --publish @semantic-release/github,@conveyal/maven-semantic-release \
-            --verify-conditions @semantic-release/github,@conveyal/maven-semantic-release \
-            --verify-release @conveyal/maven-semantic-release\
-            --use-conveyal-workflow
+
+      - name: Semantic release
+        id: semantic
+        uses: cycjimmy/semantic-release-action@v4
+        with:
+          semantic_version: 23
+          extra_plugins: |
+            @semantic-release/changelog@6
+            @terrestris/maven-semantic-release@2
+            @semantic-release/git@10
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           OSSRH_JIRA_USERNAME: ${{ secrets.OSSRH_JIRA_USERNAME }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,36 @@
+{
+  "branches": [
+    "main"
+  ],
+  "plugins": [
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    "@semantic-release/changelog",
+    [
+      "@terrestris/maven-semantic-release",
+      {
+        "mavenTarget": "deploy",
+        "clean": false,
+        "updateSnapshotVersion": true,
+        "settingsPath": "/home/runner/.m2/settings.xml",
+        "processAllModules": true
+      }
+    ],
+    [
+      "@semantic-release/git",
+      {
+        "assets": [
+          "CHANGELOG.md", "pom.xml", "**/pom.xml"
+        ],
+        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+      }
+    ],
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false,
+        "failTitle": false
+      }
+    ]
+  ]
+}

--- a/pom.xml
+++ b/pom.xml
@@ -200,20 +200,49 @@
 
     <profiles>
         <profile>
-            <id>midpoint</id>
+            <id>midpoint48</id>
             <dependencies>
                 <dependency>
                     <groupId>com.evolveum.midpoint.gui</groupId>
                     <artifactId>admin-gui</artifactId>
-                    <version>4.0.2</version>
-                    <type>jar</type>
-                    <classifier>classes</classifier>
+                    <version>4.8.4</version>
+                    <scope>provided</scope>
+                </dependency>
+                <!--
+                    Spring Boot 3.3.2 uses logback version 1.5.6
+                    https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/3.3.2/spring-boot-dependencies-3.3.2.pom
+                -->
+                <dependency>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-classic</artifactId>
+                    <version>1.5.6</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>ch.qos.logback</groupId>
+                    <artifactId>logback-core</artifactId>
+                    <version>1.5.6</version>
+                    <scope>provided</scope>
+                </dependency>
+                <!--
+                    Spring Boot 3.3.2 uses jackson version 2.17.2
+                    https://repo1.maven.org/maven2/org/springframework/boot/spring-boot-dependencies/3.3.2/spring-boot-dependencies-3.3.2.pom
+                -->
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-annotations</artifactId>
+                    <version>2.17.2</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
+                    <version>2.17.2</version>
                     <scope>provided</scope>
                 </dependency>
                 <dependency>
                     <groupId>org.testng</groupId>
                     <artifactId>testng</artifactId>
-                    <version>6.8</version>
                     <scope>test</scope>
                     <exclusions>
                         <exclusion>
@@ -221,6 +250,119 @@
                             <artifactId>snakeyaml</artifactId>
                         </exclusion>
                     </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>net.tirasa.connid</groupId>
+                    <artifactId>connector-framework</artifactId>
+                    <version>1.5.2.0</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>net.tirasa.connid</groupId>
+                    <artifactId>connector-framework-internal</artifactId>
+                    <version>1.5.2.0</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>midpoint44</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.evolveum.midpoint.gui</groupId>
+                    <artifactId>admin-gui</artifactId>
+                    <type>jar</type>
+                    <classifier>classes</classifier>
+                    <version>4.4.9</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.testng</groupId>
+                    <artifactId>testng</artifactId>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.yaml</groupId>
+                            <artifactId>snakeyaml</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>net.tirasa.connid</groupId>
+                    <artifactId>connector-framework</artifactId>
+                    <version>1.5.1.10</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>net.tirasa.connid</groupId>
+                    <artifactId>connector-framework-internal</artifactId>
+                    <version>1.5.1.10</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>net.tirasa.connid</groupId>
+                    <artifactId>connector-framework-contract</artifactId>
+                    <version>1.5.1.10</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>midpoint40</id>
+            <repositories>
+                <repository>
+                    <id>evolveum-nexus-releases</id>
+                    <name>Internal Releases</name>
+                    <url>https://nexus.evolveum.com/nexus/content/repositories/releases/</url>
+                </repository>
+                <repository>
+                    <id>evolveum-nexus-snapshots</id>
+                    <name>Internal Releases</name>
+                    <url>https://nexus.evolveum.com/nexus/content/repositories/snapshots/</url>
+                </repository>
+                <repository>
+                    <!-- Jasper references old http repository which fails with 308. -->
+                    <id>jaspersoft-third-party</id>
+                    <url>https://jaspersoft.jfrog.io/jaspersoft/third-party-ce-artifacts</url>
+                </repository>
+            </repositories>
+            <dependencies>
+                <dependency>
+                    <groupId>com.evolveum.midpoint.gui</groupId>
+                    <artifactId>admin-gui</artifactId>
+                    <type>jar</type>
+                    <classifier>classes</classifier>
+                    <version>4.0.4</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.testng</groupId>
+                    <artifactId>testng</artifactId>
+                    <scope>test</scope>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>org.yaml</groupId>
+                            <artifactId>snakeyaml</artifactId>
+                        </exclusion>
+                    </exclusions>
+                </dependency>
+                <dependency>
+                    <groupId>net.tirasa.connid</groupId>
+                    <artifactId>connector-framework</artifactId>
+                    <version>1.5.0.10</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>net.tirasa.connid</groupId>
+                    <artifactId>connector-framework-internal</artifactId>
+                    <version>1.5.0.10</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>net.tirasa.connid</groupId>
+                    <artifactId>connector-framework-contract</artifactId>
+                    <version>1.5.0.10</version>
+                    <scope>test</scope>
                 </dependency>
             </dependencies>
         </profile>

--- a/src/main/java/jp/openstandia/connector/guacamole/GuacamoleConfiguration.java
+++ b/src/main/java/jp/openstandia/connector/guacamole/GuacamoleConfiguration.java
@@ -31,6 +31,9 @@ public class GuacamoleConfiguration extends AbstractConfiguration {
     private String httpProxyUser;
     private GuardedString httpProxyPassword;
     private boolean suppressInvitationMessageEnabled = true;
+    private int connectionTimeoutInMilliseconds = 20000;
+    private int readTimeoutInMilliseconds = 15000;
+    private int writeTimeoutInMilliseconds = 15000;
 
     @ConfigurationProperty(
             order = 1,
@@ -147,6 +150,48 @@ public class GuacamoleConfiguration extends AbstractConfiguration {
         this.httpProxyPassword = httpProxyPassword;
     }
 
+    @ConfigurationProperty(
+            order = 9,
+            displayMessageKey = "Connection Timeout (in milliseconds)",
+            helpMessageKey = "Connection timeout when connecting to Guacamole API. (Default: 20000)",
+            required = false,
+            confidential = false)
+    public int getConnectionTimeoutInMilliseconds() {
+        return connectionTimeoutInMilliseconds;
+    }
+
+    public void setConnectionTimeoutInMilliseconds(int connectionTimeoutInMilliseconds) {
+        this.connectionTimeoutInMilliseconds = connectionTimeoutInMilliseconds;
+    }
+
+    @ConfigurationProperty(
+            order = 10,
+            displayMessageKey = "Connection Read Timeout (in milliseconds)",
+            helpMessageKey = "Connection read timeout when connecting to Guacamole API. (Default: 15000)",
+            required = false,
+            confidential = false)
+    public int getReadTimeoutInMilliseconds() {
+        return readTimeoutInMilliseconds;
+    }
+
+    public void setReadTimeoutInMilliseconds(int readTimeoutInMilliseconds) {
+        this.readTimeoutInMilliseconds = readTimeoutInMilliseconds;
+    }
+
+    @ConfigurationProperty(
+            order = 11,
+            displayMessageKey = "Connection Write Timeout (in milliseconds)",
+            helpMessageKey = "Connection write timeout when connecting to Guacamole API. (Default: 15000)",
+            required = false,
+            confidential = false)
+    public int getWriteTimeoutInMilliseconds() {
+        return writeTimeoutInMilliseconds;
+    }
+
+    public void setWriteTimeoutInMilliseconds(int writeTimeoutInMilliseconds) {
+        this.writeTimeoutInMilliseconds = writeTimeoutInMilliseconds;
+    }
+    
     @Override
     public void validate() {
         if (guacamoleURL == null) {

--- a/src/main/java/jp/openstandia/connector/guacamole/GuacamoleConnector.java
+++ b/src/main/java/jp/openstandia/connector/guacamole/GuacamoleConnector.java
@@ -73,9 +73,9 @@ public class GuacamoleConnector implements PoolableConnector, CreateOp, UpdateDe
 
     protected void authenticateResource() {
         OkHttpClient.Builder okHttpBuilder = new OkHttpClient.Builder();
-        okHttpBuilder.connectTimeout(20, TimeUnit.SECONDS);
-        okHttpBuilder.readTimeout(15, TimeUnit.SECONDS);
-        okHttpBuilder.writeTimeout(15, TimeUnit.SECONDS);
+        okHttpBuilder.connectTimeout(configuration.getConnectionTimeoutInMilliseconds(), TimeUnit.MILLISECONDS);
+        okHttpBuilder.readTimeout(configuration.getReadTimeoutInMilliseconds(), TimeUnit.MILLISECONDS);
+        okHttpBuilder.writeTimeout(configuration.getWriteTimeoutInMilliseconds(), TimeUnit.MILLISECONDS);
         okHttpBuilder.addInterceptor(getInterceptor());
 
         // Setup cookie manager for multiple guacamole nodes with sticky session cookie


### PR DESCRIPTION
In particular, since the Guacamole API does not provide paging function,
timeout is likely to occur if the number of resources is large,
and the timeout settings should be adjustable.